### PR TITLE
add find_host_file macro

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -1518,6 +1518,7 @@ set( ANDROID True )
 set( BUILD_ANDROID True )
 
 # where is the target environment
+set( _host_cmake_find_root_path ${CMAKE_FIND_ROOT_PATH} )
 set( CMAKE_FIND_ROOT_PATH "${ANDROID_TOOLCHAIN_ROOT}/bin" "${ANDROID_TOOLCHAIN_ROOT}/${ANDROID_TOOLCHAIN_MACHINE_NAME}" "${ANDROID_SYSROOT}" "${CMAKE_INSTALL_PREFIX}" "${CMAKE_INSTALL_PREFIX}/share" )
 
 # only search for libraries and includes in the ndk toolchain
@@ -1567,6 +1568,25 @@ macro( find_host_program )
  set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY )
  set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
  set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+endmacro()
+
+
+# macro to find files on the host OS
+macro( find_host_file)
+ SET( _save_root_path ${CMAKE_FIND_ROOT_PATH} )
+ SET( CMAKE_FIND_ROOT_PATH ${_host_cmake_find_root_path} )
+ if( CMAKE_HOST_WIN32 )
+  SET( WIN32 1 )
+  SET( UNIX )
+ elseif( CMAKE_HOST_APPLE )
+  SET( APPLE 1 )
+  SET( UNIX )
+ endif()
+ find_file( ${ARGN} )
+ SET( WIN32 )
+ SET( APPLE )
+ SET( UNIX 1 )
+ SET( CMAKE_FIND_ROOT_PATH $_save_root_path )
 endmacro()
 
 


### PR DESCRIPTION
This pull request adds a `find_host_file` macro to cmake `find_file`, just like `find_host_package` to the original `find_package`.

I personally experienced the issue with `find_file` when building https://github.com/rlei/fastd-android using android-cmake. [One of its cmake files](https://github.com/rlei/fastd-android/blob/master/cmake/UseDoxygen.cmake#L72) has the following
```cmake
	find_file(DOXYFILE_IN "Doxyfile.in"
			PATHS "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_ROOT}/Modules/"
			NO_DEFAULT_PATH
			DOC "Path to the doxygen configuration template file")
```
which can't find the file `Doxyfile.in` in the `CMAKE_CURRENT_SOURCE_DIR` folder. With the new macro it works fine.

And thanks for your nice work on android-cmake :)
