### PR TITLE
Fix typo that happened with LIBRARY_OUTPUT_PATH_ROOT

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -1487,7 +1487,7 @@ endif()
 # setup output directories
 set( CMAKE_INSTALL_PREFIX "${ANDROID_TOOLCHAIN_ROOT}/user" CACHE STRING "path for installing" )
 
-if( DEFINED LIBRARY_OUTPUT_PATH_ROOT
+if( NOT DEFINED LIBRARY_OUTPUT_PATH_ROOT
       OR EXISTS "${CMAKE_SOURCE_DIR}/AndroidManifest.xml"
       OR (EXISTS "${CMAKE_SOURCE_DIR}/../AndroidManifest.xml" AND EXISTS "${CMAKE_SOURCE_DIR}/../jni/") )
   set( LIBRARY_OUTPUT_PATH_ROOT ${CMAKE_SOURCE_DIR} CACHE PATH "Root for binaries output, set this to change where Android libs are installed to" )


### PR DESCRIPTION
The check was inversed which causes the block of code to overwrite LIBRARY_OUTPUT_PATH_ROOT only if it was previously defined.
This is obviously the opposite of what is wanted, and should be the other way around.