### PR TITLE
Make ANDROID a cache variable.

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -1514,7 +1514,7 @@ endif()
 
 
 # set these global flags for cmake client scripts to change behavior
-set( ANDROID True )
+set( ANDROID True CACHE BOOL "Android" )
 set( BUILD_ANDROID True )
 
 # where is the target environment


### PR DESCRIPTION
Some projects that use CMake and support Android have something in their CMakeLists.txt like:
OPTION( ANDROID "Build for Android NDK" OFF )

Using this toolchain file won't override the ANDROID option the first time CMake runs unless ANDROID is a cache variable.