### PR TITLE
Fix an apparent typo involved in detecting toolchains.

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -598,7 +598,7 @@ if( BUILD_WITH_ANDROID_NDK )
  endif()
  if( NOT __availableToolchains )
   file( GLOB __availableToolchainsLst RELATIVE "${ANDROID_NDK_TOOLCHAINS_PATH}" "${ANDROID_NDK_TOOLCHAINS_PATH}/*" )
-  if( __availableToolchains )
+  if( __availableToolchainsLst )
    list(SORT __availableToolchainsLst) # we need clang to go after gcc
   endif()
   __LIST_FILTER( __availableToolchainsLst "^[.]" )


### PR DESCRIPTION
If __availableToolchains is falsish, file( GLOB __availableToolchainsLst ...
won't do anything to change that, so the following if statement is always false.

I'm not sure exactly the logic that section is trying to implement or how to test it, but if nothing else I wanted to bring it up since there's a logic error of some sort there.
