### PR TITLE
properly set up the sysroot for e.g. check_headers

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -1189,6 +1189,7 @@ if( ANDROID_SYSROOT MATCHES "[ ;\"]" )
 else()
  set( ANDROID_CXX_FLAGS "--sysroot=${ANDROID_SYSROOT}" )
 endif()
+set( CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${ANDROID_CXX_FLAGS}" )
 
 # NDK flags
 if (ARM64_V8A )


### PR DESCRIPTION
without this, cmake wasn't able to find any header for me, it got unresolved linker problems with the non-standalone toolchain:
- crtbegin_dynamic.o
- crtend_android.o
- cannot find -lc
- cannot find -ldl

all of the above mentioned issues are fixed by this.
