### PR TITLE
Forced response files for build commands

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -215,6 +215,16 @@ set( CMAKE_SYSTEM_VERSION 1 )
 set( CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "" )
 set( CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries." )
 
+# force use response files for linking, archiving libs, and includes
+# because the command lines may get too long
+# This happens especially often in Windows, where the limit is just 32k
+set(CMAKE_C_USE_RESPONSE_FILE_FOR_LIBRARIES 1)
+set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_LIBRARIES 1)
+set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+set(CMAKE_C_USE_RESPONSE_FILE_FOR_INCLUDES 1)
+set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES 1)
+
 # NDK search paths
 set( ANDROID_SUPPORTED_NDK_VERSIONS ${ANDROID_EXTRA_NDK_VERSIONS} -r10d -r10c -r10b -r10 -r9d -r9c -r9b -r9 -r8e -r8d -r8c -r8b -r8 -r7c -r7b -r7 -r6b -r6 -r5c -r5b -r5 "" )
 if( NOT DEFINED ANDROID_NDK_SEARCH_PATHS )


### PR DESCRIPTION
The maximum command line length in Windows is 32kb. The windows generators in CMake support this by setting a hard limit on a command line of 30 k, and splitting however appropriate. 

However when generating (and building) Unix makefiles in Windows there is no command line limit.

This pull request forces the generation of response files for includes, archiving libs, and linking executables and dyn libs, thus greatly reducing the command line in windows builds and making hitting the limit very, very unlikely.
