### PR TITLE
Do not clear linker flag.

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -1322,7 +1322,6 @@ set( ANDROID_RELRO                  ${ANDROID_RELRO}                  CACHE BOOL
 mark_as_advanced( ANDROID_NO_UNDEFINED ANDROID_SO_UNDEFINED ANDROID_FUNCTION_LEVEL_LINKING ANDROID_GOLD_LINKER ANDROID_NOEXECSTACK ANDROID_RELRO )
 
 # linker flags
-set( ANDROID_LINKER_FLAGS "" )
 
 if( ARMEABI_V7A )
  # this is *required* to use the following linker flags that routes around


### PR DESCRIPTION
Not clearing the ANDROID_LINKER_FLAG lets you pass initial values from the command line.

Use case:
We are using the script to crosscompile a collection of libraries which are not designed for Android and we need an easy way to add the android libraries (for logging, etc) to the link process.
https://github.com/ernestmc/roscpp_android/commit/114800b632e05161d266c5216527ba7f7077af3f
